### PR TITLE
Feature/엔티티생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ build
 #application.properties
 .env
 *.env
+DB
 
 #AWS관련 보안 파일
 .aws/

--- a/src/main/java/com/dnd12/meetinginvitation/domain/attendence/entity/Attendance.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/attendence/entity/Attendance.java
@@ -1,0 +1,35 @@
+package com.dnd12.meetinginvitation.domain.attendence.entity;
+
+import com.dnd12.meetinginvitation.domain.invitation.entity.Invitation;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "attendance")
+public class Attendance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "invitation_id", nullable = false)
+    private Invitation invitation;
+
+    @Column(nullable = false)
+    private String state;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ElementCollection
+    private java.util.List<String> messages;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Font.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Font.java
@@ -1,0 +1,21 @@
+package com.dnd12.meetinginvitation.domain.invitation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "font")
+public class Font {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fontName;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Invitation.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Invitation.java
@@ -1,0 +1,49 @@
+package com.dnd12.meetinginvitation.domain.invitation.entity;
+
+import com.dnd12.meetinginvitation.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "invitation")
+public class Invitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt;
+
+    private String place;
+    private String detailAddress;
+    private LocalDateTime date;
+
+    @Column(nullable = false)
+    private int maxAttendences;
+
+    private String description;
+
+    @Column(nullable = false)
+    private String state;
+
+    private String link;
+
+    @Lob
+    private byte[] invitationTemplate;
+
+    private String invitationType;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Stickers.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Stickers.java
@@ -1,0 +1,21 @@
+package com.dnd12.meetinginvitation.domain.invitation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "stickers")
+public class Stickers {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Template.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/invitation/entity/Template.java
@@ -1,0 +1,21 @@
+package com.dnd12.meetinginvitation.domain.invitation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "template")
+public class Template {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/domain/user/controller/KakaoLoginController.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/user/controller/KakaoLoginController.java
@@ -1,7 +1,7 @@
-package com.dnd12.meetinginvitation.controller;
+package com.dnd12.meetinginvitation.domain.user.controller;
 
-import com.dnd12.meetinginvitation.service.KakaoService;
-import com.dnd12.meetinginvitation.service.KakaoTokenResponseDto;
+import com.dnd12.meetinginvitation.domain.user.service.KakaoService;
+import com.dnd12.meetinginvitation.domain.user.dto.KakaoTokenResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/dnd12/meetinginvitation/domain/user/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/user/dto/KakaoTokenResponseDto.java
@@ -1,4 +1,4 @@
-package com.dnd12.meetinginvitation.service;
+package com.dnd12.meetinginvitation.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/dnd12/meetinginvitation/domain/user/entity/User.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/user/entity/User.java
@@ -1,0 +1,33 @@
+package com.dnd12.meetinginvitation.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "users") // 'user'는 예약어이므로 'users'로 지정
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Lob
+    private byte[] profileImage;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/domain/user/service/KakaoService.java
+++ b/src/main/java/com/dnd12/meetinginvitation/domain/user/service/KakaoService.java
@@ -1,5 +1,6 @@
-package com.dnd12.meetinginvitation.service;
+package com.dnd12.meetinginvitation.domain.user.service;
 
+import com.dnd12.meetinginvitation.domain.user.dto.KakaoTokenResponseDto;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
## What is this PR? :mag:
1. 기존 소셜 로그인 도메인 구조에 맞게 domain/user패키지 안으로 이동
2. DB설계에 따른 엔티티 생성 -> 도메인 구조 및 엔티티 검토 필요
    2-1. DB설계에서 user테이블명을 users로 변경 (user의 경우 예약어로 사용하지 않는게 좋음)
    2-2. DB설계에서 postgresql에서 지원하는 타입으로 변경
          + long -> serial(pk값일 경우) or binint(설계에서 Long으로 사용한 경우)
          + datetime -> timestamp
3. DB생성 테이블 생성 쿼리의 경우 DB파일로 작성함(보안상 gitignore, 개인적으로 공유)

## Changes :memo:

## Screenshot :camera:
