### PR TITLE
feature/초대장생성+초대장목록확인+초대장수정/삭제

### DIFF
--- a/src/main/java/com/dnd12/meetinginvitation/conf/WebConfig.java
+++ b/src/main/java/com/dnd12/meetinginvitation/conf/WebConfig.java
@@ -1,0 +1,27 @@
+package com.dnd12.meetinginvitation.conf;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final String UPLOAD_DIR;
+
+    //정적리소스 제공 -> spring에서 /uploads/ url(DB에 저장되는 이미지 경로)로 이미지 접근 가능하도록 설정
+    public WebConfig() {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            UPLOAD_DIR = "file:C:\\Users\\USER\\OneDrive\\바탕 화면\\DND12기\\테스트데이터\\uploads";
+        } else {
+            UPLOAD_DIR = "file:/var/www/uploads/";
+        }
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(UPLOAD_DIR);
+    }
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
@@ -1,0 +1,73 @@
+package com.dnd12.meetinginvitation.invitation.controller;
+
+import com.dnd12.meetinginvitation.invitation.dto.InvitationDto;
+import com.dnd12.meetinginvitation.invitation.dto.ResponseDto;
+import com.dnd12.meetinginvitation.invitation.service.FileStorageService;
+import com.dnd12.meetinginvitation.invitation.service.InvitationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+public class InvitationController {
+
+    @Autowired
+    private InvitationService invitationService;
+
+    @Autowired
+    private FileStorageService fileStorageService;
+
+    @RequestMapping(value = "/makeInvitation", method = RequestMethod.PUT)
+    public ResponseEntity<ResponseDto> makeInvitation(@ModelAttribute InvitationDto invitationDto){
+        return invitationService.makeInvitation(invitationDto);
+    }
+
+    @RequestMapping(value = "/getInvitationAllList", method = RequestMethod.GET)
+    public ResponseEntity<ResponseDto> getInvitationAllList(@RequestParam("userId") Long userId){
+        return invitationService.getInvitationAllList(userId);
+    }
+
+    @RequestMapping(value = "/getInvitationImage", method = RequestMethod.GET)
+    public ResponseEntity<Resource> getInvitationImage(@RequestParam("fileName") String fileName){
+        try {
+            Path filePath =Path.of(Paths.get(fileStorageService.getUploadDir()) + "/" + fileName);
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (resource.exists()) {
+                return ResponseEntity.ok()
+                        .contentType(MediaType.IMAGE_PNG) // 이미지 MIME 타입 지정
+                        .body(resource);
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+        } catch (MalformedURLException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+
+    @RequestMapping(value = "/modifyInvitation", method = RequestMethod.PUT)
+    public ResponseEntity<ResponseDto> modifyInvitation(@RequestParam("invitationId") Long invitationId, @ModelAttribute InvitationDto invitationDto){
+        return invitationService.modifyInvitation(invitationId, invitationDto);
+    }
+
+    @DeleteMapping(value = "/deleteInvitation/{invitationId}")
+    public ResponseEntity<ResponseDto> deleteInvitation(@PathVariable("invitationId") Long invitationId){
+        return invitationService.deleteInvitation(invitationId);
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/dto/InvitationDto.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/dto/InvitationDto.java
@@ -1,0 +1,31 @@
+package com.dnd12.meetinginvitation.invitation.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvitationDto {
+    private Long creator_id;
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private String place;
+    private String detail_address;
+    private LocalDateTime date;
+    private int max_attendances;
+    private String description;
+    private String state;
+    private String link;
+    private MultipartFile invitationTemplate;
+    private String invitationTemplate_url;
+    private String invitationType;
+
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/dto/ResponseDto.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/dto/ResponseDto.java
@@ -1,0 +1,28 @@
+package com.dnd12.meetinginvitation.invitation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseDto {
+
+    private String result;
+    private String message;
+    private List<?> data;
+
+    public static ResponseDto success(List<?> data){
+        return new ResponseDto("success" , "", data);
+    }
+
+    public static ResponseDto fail(String message){
+        return new ResponseDto("fail" , message, Collections.singletonList(""));
+    }
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/entity/Invitation.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/entity/Invitation.java
@@ -45,4 +45,6 @@ public class Invitation {
     private String invitationTemplate_url;
 
     private String invitationType;
+
+
 }

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/repository/InvitationRepository.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/repository/InvitationRepository.java
@@ -1,0 +1,15 @@
+package com.dnd12.meetinginvitation.invitation.repository;
+
+
+import com.dnd12.meetinginvitation.invitation.entity.Invitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+    List<Invitation> findByUserId(Long userId);
+
+    Invitation findByid(Long id);
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/service/FileStorageService.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/service/FileStorageService.java
@@ -1,0 +1,72 @@
+package com.dnd12.meetinginvitation.invitation.service;
+
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    private final String UPLOAD_DIR;
+
+    public FileStorageService(){
+        String os = System.getProperty("os.name").toLowerCase();
+        if(os.contains("win")){
+            // 배포전 테스트 환경
+            UPLOAD_DIR = "C:\\Users\\USER\\OneDrive\\바탕 화면\\DND12기\\테스트데이터\\uploads";
+        }else{
+            //실제 배포시 저장 경로
+            UPLOAD_DIR = "/var/www/uploads";
+        }
+    }
+
+    public String saveFile(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+
+        // 폴더가 존재하지 않으면 생성
+        File directory = new File(UPLOAD_DIR);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        // 고유한 파일명 생성 (UUID 사용)
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        String newFileName = UUID.randomUUID().toString() + extension;
+
+        // 파일 저장
+        String filePath = Paths.get(UPLOAD_DIR, newFileName).toString();
+        file.transferTo(new File(filePath));
+
+        // 저장된 이미지 URL 반환
+        //return "/uploads/" + newFileName;
+        return newFileName;
+    }
+
+    // 파일을 MultipartFile로 변환하는 메서드
+    public MultipartFile loadFileAsMultipartFile(String fileName) throws IOException {
+        // 파일 경로로부터 파일을 읽음
+        //Path filePath = Paths.get(UPLOAD_DIR).resolve(fileName).normalize();
+        //filePath = Path.of(Paths.get(UPLOAD_DIR) + "/e5c05854-da8a-401c-a303-dc14aaac0913.png");
+        Path filePath = Path.of(Paths.get(UPLOAD_DIR) + "/" + fileName);
+        File file = filePath.toFile();
+
+        // InputStream을 이용해 MockMultipartFile로 변환
+        return new MockMultipartFile(file.getName(), new FileInputStream(file));
+    }
+
+    // 저장된 경로 반환
+    public String getUploadDir() {
+        return UPLOAD_DIR;
+    }
+
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
@@ -1,0 +1,188 @@
+package com.dnd12.meetinginvitation.invitation.service;
+
+
+import com.dnd12.meetinginvitation.invitation.dto.InvitationDto;
+import com.dnd12.meetinginvitation.invitation.dto.ResponseDto;
+import com.dnd12.meetinginvitation.invitation.entity.Invitation;
+import com.dnd12.meetinginvitation.invitation.repository.InvitationRepository;
+import com.dnd12.meetinginvitation.user.entity.User;
+import com.dnd12.meetinginvitation.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class InvitationService {
+
+    @Autowired
+    private InvitationRepository invitationRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private FileStorageService fileStorageService;
+
+    //초대장 생성
+    public ResponseEntity<ResponseDto> makeInvitation(InvitationDto invitationDto){
+
+        try {
+
+            // User 조회 (creator_id를 통해)
+            User user = userRepository.findById(invitationDto.getCreator_id())
+                    .orElseThrow(() -> new RuntimeException("Fail: user not found with id: " + invitationDto.getCreator_id()));
+
+            //파일 저장 처리
+            String fileUrl = null;
+            MultipartFile file = invitationDto.getInvitationTemplate();
+            if(file != null && !file.isEmpty()){
+                //ip주소는 제외하고 저장 -> 도메인이나 고정IP를 사용하지 않기 때문
+                //프론트에서 http://IP주소:PORT/fileUrl형태로 사용
+                fileUrl = "/getInvitationImage?fileName=" +  fileStorageService.saveFile(file);
+            }
+
+            Invitation invitation = Invitation.builder()
+                    .user(user)
+                    .createdAt(invitationDto.getCreated_at())
+                    .place(invitationDto.getPlace())
+                    .detailAddress(invitationDto.getDetail_address())
+                    .date(invitationDto.getDate())
+                    .maxAttendences(invitationDto.getMax_attendances())
+                    .description(invitationDto.getDescription())
+                    .state(invitationDto.getState())
+                    .link(invitationDto.getLink())
+                    .invitationTemplate_url(fileUrl)
+                    .invitationType(invitationDto.getInvitationType())
+                    .build();
+
+            invitationRepository.save(invitation);
+            return ResponseEntity.ok(ResponseDto.success(Collections.singletonList("")));
+
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ResponseDto.fail(e.getMessage()));
+        }
+
+    }
+
+    
+    //초대장 전체 조회
+    @Transactional(readOnly = true)
+    public ResponseEntity<ResponseDto> getInvitationAllList(Long userId){
+
+        if(!userRepository.existsById(userId)){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ResponseDto.fail("Fail: user not found with id: " + userId));
+        }
+
+
+        List<Invitation> list = invitationRepository.findByUserId(userId);
+        List<InvitationDto> invitationList = new ArrayList<>();
+
+        for (Invitation invitation : list) {
+
+            // URL 경로로 MultipartFile을 로드하기 위해 FileStorageService 사용
+            //MultipartFile invitationTemplate = fileStorageService.loadFileAsMultipartFile(invitation.getInvitationTemplate_url());
+            
+            invitationList.add(new InvitationDto(
+                    invitation.getUser().getId(),
+                    invitation.getCreatedAt(),
+                    invitation.getUpdatedAt(),
+                    invitation.getPlace(),
+                    invitation.getDetailAddress(),
+                    invitation.getDate(),
+                    invitation.getMaxAttendences(),
+                    invitation.getDescription(),
+                    invitation.getState(),
+                    invitation.getLink(),
+                    //invitationTemplate,
+                    null,
+                    invitation.getInvitationTemplate_url(),
+                    invitation.getInvitationType()
+            ));
+
+        }
+        return ResponseEntity.ok(ResponseDto.success(invitationList));
+    }
+
+//초대장 수정
+public ResponseEntity<ResponseDto> modifyInvitation(Long id, InvitationDto invitationDto){
+
+    //초대장 조회
+    Optional<Invitation> optionalInvitation = invitationRepository.findById(id);
+    if (!optionalInvitation.isPresent()) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDto.fail("Fail: Invitation found with id " + id));
+    }
+
+    Invitation invitation = optionalInvitation.get();
+    if(invitationDto.getPlace() != null){
+        invitation.setPlace(invitationDto.getPlace());
+    }
+    if(invitationDto.getDetail_address() != null){
+        invitation.setDetailAddress(invitationDto.getDetail_address());
+    }
+    if(invitationDto.getDate() != null){
+        invitation.setDate(invitationDto.getDate());
+    }
+    //해당 값은 수정을 안해도 기존 값 넘겨주어야 한다
+    invitation.setMaxAttendences(invitationDto.getMax_attendances());
+    if(invitationDto.getDescription() != null){
+        invitation.setDescription(invitationDto.getDescription());
+    }
+    //해당 값은 수정을 안해도 기존 값 넘겨주어야 한다.
+    invitationDto.setState(invitationDto.getState());
+    if(invitationDto.getLink() != null){
+        invitation.setLink(invitationDto.getLink());
+    }
+
+    //파일 저장 처리
+    String fileUrl = null;
+    MultipartFile file = invitationDto.getInvitationTemplate();
+    if(file != null && !file.isEmpty()){
+        //ip주소는 제외하고 저장 -> 도메인이나 고정IP를 사용하지 않기 때문
+        //프론트에서 http://IP주소:PORT/fileUrl형태로 사용
+        try {
+            fileUrl = "/getInvitationImage?fileName=" +  fileStorageService.saveFile(file);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ResponseDto.fail(e.getMessage()));
+        }
+    }
+
+    if(invitationDto.getInvitationTemplate() != null){
+        invitation.setInvitationTemplate_url(fileUrl);
+    }
+
+    invitation.setUpdatedAt(LocalDateTime.now());
+
+    invitationRepository.save(invitation);
+    return ResponseEntity.ok(ResponseDto.success(Collections.singletonList("")));
+
+}
+
+//초대장 삭제
+public ResponseEntity<ResponseDto> deleteInvitation(Long invitationId){
+    boolean isDeleted = invitationRepository.existsById(invitationId);
+    if(!isDeleted){
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDto.fail("Fail: Invitation found with id " + invitationId));
+    }
+    invitationRepository.deleteById(invitationId);
+    return ResponseEntity.ok(ResponseDto.success(Collections.singletonList("")));
+}
+
+
+
+
+
+
+}

--- a/src/main/java/com/dnd12/meetinginvitation/user/repository/UserRepository.java
+++ b/src/main/java/com/dnd12/meetinginvitation/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.dnd12.meetinginvitation.user.repository;
+
+import com.dnd12.meetinginvitation.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## What is this PR? :mag:
- 초대장 생성 후 DB저장 기능 개발
  + 초대장 생성시 이미지 form data를 윈도우 or 리눅스 특정 경로에 저장하고 DB에는 해당 url저장
  + url저장시 IP주소는 제외 -> 현재 동적IP를 사용하지 않기 때문 프론트에서 앞에 http://<IP주소>:<PORT>/<반환url> 형식으 
    로 사용
  + 현재 aws리눅스에 특정 경로에 이미지를 저장하게 될 경우 이미지에 대한 요청이 증가하고 이미지가 많아질 경우 프리티어 
     로 사용하기에는 서버 스펙에 한계가 있을 수 있음 (이미지를 직접 저장 vs url로 제공할 것인지 고민 필요)
- 초대장 목록 확인 기능 개발
  + 초대장 목록 확인 시 초대장 이미지는 이미지 저장 경로 반환
- 초대장 수정/삭제 기능 개발
## Changes :memo:
- 초대장 생성 API 수정: /invitation -> makeInvitation
- 초대장 전체 리스트  호출 API수정 : /invitation/{userId} -> getInvitationAllList/{userId}
- 초대장 수정 API 수정 : invitatoin/{invitationid} -> modifyInvitationId/{invitationId}
- 초대장 삭제 API 수정 : invitation/{invitationId} -> deleteInvitation/{invitationId}

!!!!!별도 추가 필요!!!!!!
build.gradle : implementation  group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '3.4.2'
## Screenshot :camera:
