### PR TITLE
Chore/배포설정파일수정,초대장생성수정

### DIFF
--- a/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
@@ -63,7 +63,7 @@ public class InvitationController {
     }
 
     //생성한 초대장 전체 조회(페이징)
-    @Operation(summary = "생성한 초대장 초회", description = "EX) page=0(첫 번째 페이지), size=10(한 페이지에 10개씩), sort=desc(최신순 정렬)")
+    @Operation(summary = "생성한 초대장 조회", description = "EX) page=0(첫 번째 페이지), size=10(한 페이지에 10개씩), sort=desc(최신순 정렬)")
     @RequestMapping(value = "/creatorInvitations", method = RequestMethod.GET)
     public ResponseEntity<ResponseDto> getCreatorInvitations(
             @RequestParam("userId") Long userId,

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
@@ -51,6 +51,13 @@ public class InvitationController {
         return invitationService.makeSticker(stickerName);
     }
 
+    //편지지 종류 추가
+    @Operation(summary = "편지지 종류 추가", description = "")
+    @RequestMapping(value = "/theme", method = RequestMethod.POST)
+    public ResponseEntity<ResponseDto>  makeTheme(@RequestParam("themeName") String themeName){
+        return invitationService.makeTheme(themeName);
+    }
+
     //초대장 전체 조회(페이징) (Form-Data)
     @Operation(summary = "초대장 전체 조회", description = "EX) page=0(첫 번째 페이지), size=10(한 페이지에 10개씩), sort=desc(최신순 정렬)")
     @RequestMapping(value = "/invitations", method = RequestMethod.GET)

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/controller/InvitationController.java
@@ -85,6 +85,15 @@ public class InvitationController {
         return invitationService.getInvitedInvitationAllList(userId, page, size, sort);
     }
 
+    //특정 초대장 조회
+    @Operation(summary = "특정 초대장 조회", description = "")
+    @RequestMapping(value = "/specificInvitation", method = RequestMethod.GET)
+    public ResponseEntity<ResponseDto> getSpecificInvitation(
+            @RequestParam("invitationId") Long invitationId
+    ){
+        return invitationService.getSpecificInvitation(invitationId);
+    }
+
     //초대장 이미지 요청(썸네일)
     @Operation(summary = "초대장 배경 이미지 조회", description = "오류 발생시 404로 예외처리 필요")
     @RequestMapping(value = "/getInvitationImage", method = RequestMethod.GET)

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/dto/InvitationDto.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/dto/InvitationDto.java
@@ -26,10 +26,35 @@ public class InvitationDto {
     private String state;
     private String link;
     private InvitationType invitationType;
-    //private String imageData;
-    //private String invitationTemplate_url;
     private String fontName;
     private String sticker;
     private String title;
     private String backgroundImageData;
+
+
+    public InvitationDto(Long creator_id, Long invitationId, LocalDateTime created_at,
+                               LocalDateTime updated_at, String place, String detail_address,
+                               LocalDateTime date, int max_attendances, String description,
+                               String state, String link, String fontName, String sticker, String title, String backgroundImageData) {
+        this.creator_id = creator_id;
+        this.invitationId = invitationId;
+        this.created_at = created_at;
+        this.updated_at = updated_at;
+        this.place = place;
+        this.detail_address = detail_address;
+        this.date = date;
+        this.max_attendances = max_attendances;
+        this.description = description;
+        this.state = state;
+        this.link = link;
+        this.fontName = fontName;
+        this.sticker = sticker;
+        this.title = title;
+        this.backgroundImageData = backgroundImageData;
+    }
+
+
 }
+
+
+

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/dto/InvitationDto.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/dto/InvitationDto.java
@@ -30,30 +30,12 @@ public class InvitationDto {
     private String sticker;
     private String title;
     private String backgroundImageData;
+    private String organizerName;
+    private String themeName;
 
 
-    public InvitationDto(Long creator_id, Long invitationId, LocalDateTime created_at,
-                               LocalDateTime updated_at, String place, String detail_address,
-                               LocalDateTime date, int max_attendances, String description,
-                               String state, String link, String fontName, String sticker, String title, String backgroundImageData) {
-        this.creator_id = creator_id;
-        this.invitationId = invitationId;
-        this.created_at = created_at;
-        this.updated_at = updated_at;
-        this.place = place;
-        this.detail_address = detail_address;
-        this.date = date;
-        this.max_attendances = max_attendances;
-        this.description = description;
-        this.state = state;
-        this.link = link;
-        this.fontName = fontName;
-        this.sticker = sticker;
-        this.title = title;
-        this.backgroundImageData = backgroundImageData;
+    public InvitationDto(Long id, Long id1, LocalDateTime createdAt, LocalDateTime updatedAt, String organizerName, String place, String detailAddress, LocalDateTime date, int maxAttendences, String description, String state, String link, String title, String fontName, String stickerName, String backgroundUrl, String themeName) {
     }
-
-
 }
 
 

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/entity/Invitation.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/entity/Invitation.java
@@ -33,7 +33,7 @@ public class Invitation {
     private LocalDateTime createdAt = LocalDateTime.now();
 
     private LocalDateTime updatedAt;
-
+    private String organizerName;
     private String place;
     private String detailAddress;
     private LocalDateTime date;
@@ -63,6 +63,11 @@ public class Invitation {
 //    @OneToOne
 //    @JoinColumn(name = "template_id", nullable = false)
 //    private Background background;
+
+    // 편지지 종류
+    @ManyToOne
+    @JoinColumn(name = "theme_id", nullable = true)
+    private Theme theme;
 
     private String backgroundUrl;
 }

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/entity/Theme.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/entity/Theme.java
@@ -1,0 +1,21 @@
+package com.dnd12.meetinginvitation.invitation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "theme")
+public class Theme {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String themeName;
+}

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/repository/InvitationRepository.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/repository/InvitationRepository.java
@@ -6,14 +6,19 @@ import com.dnd12.meetinginvitation.invitation.enums.InvitationType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     List<Invitation> findByUserId(Long userId);
-    Invitation findByid(Long id);
+    Optional<Invitation> findById(Long id);
+    @Query("SELECT i FROM Invitation i WHERE i.id = :id")
+    Invitation findInvitationById(@Param("id") Long id);
     Page<Invitation> findByUserId(Long userId, Pageable pageable);
     Page<Invitation> findByParticipantsUserIdAndParticipantsInvitationType(Long userId, InvitationType invitationType, Pageable pageable);
 }

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/repository/ThemeRepository.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/repository/ThemeRepository.java
@@ -1,0 +1,13 @@
+package com.dnd12.meetinginvitation.invitation.repository;
+
+import com.dnd12.meetinginvitation.invitation.entity.Theme;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ThemeRepository extends JpaRepository<Theme, Long> {
+    Optional<Theme> findByThemeName(String themeName);
+}
+

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
@@ -159,7 +159,6 @@ public class InvitationService {
     //초대장 전체 조회
     @Transactional(readOnly = true)
     public ResponseEntity<ResponseDto> getInvitationAllList(Long userId, int page, int size, String sort) {
-
         return getInvitationListByParam(userId, page, size, sort, "ALL");
     }
 
@@ -174,6 +173,31 @@ public class InvitationService {
     @Transactional(readOnly = true)
     public ResponseEntity<ResponseDto> getInvitedInvitationAllList(Long userId, int page, int size, String sort) {
         return getInvitationListByParam(userId, page, size, sort, "INVITED");
+    }
+
+    //특정 초대장 조회
+    public ResponseEntity<ResponseDto> getSpecificInvitation(Long invitationId){
+        Invitation invitation = invitationRepository.findByid(invitationId);
+        List<InvitationDto> invitationList = new ArrayList<>();
+
+        invitationList.add(new InvitationDto(
+                invitation.getUser().getId(),
+                invitation.getId(),
+                invitation.getCreatedAt(),
+                invitation.getUpdatedAt(),
+                invitation.getPlace(),
+                invitation.getDetailAddress(),
+                invitation.getDate(),
+                invitation.getMaxAttendences(),
+                invitation.getDescription(),
+                invitation.getState(),
+                invitation.getLink(),
+                invitation.getTitle(),
+                invitation.getFont().getFontName(),
+                invitation.getSticker().getStickerName(),
+                invitation.getBackgroundUrl()
+        ));
+        return ResponseEntity.ok(ResponseDto.success(invitationList));
     }
 
 

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
@@ -64,7 +64,15 @@ public class InvitationService {
             Font font = fontRepository.findByFontName(invitationDto.getFontName())
                     .orElseThrow(() -> new RuntimeException("Fail: font not found with name: " + invitationDto.getFontName()));
 
-            //전달 받은 스티커 이름으로 스티커 조회
+            //전달 받은 스티커 이름으로 스티커 조회(1. 빈문자열 또는 null일 경우)
+            if (invitationDto.getSticker() == null || invitationDto.getSticker().trim().isEmpty() && invitationDto.getSticker().trim().equals("")) {
+                invitationDto.setSticker(null);
+                Optional<Sticker> sticker = stickerRepository.findByStickerName(invitationDto.getSticker());
+                if(sticker.isEmpty()){
+                    makeSticker(null);
+                }
+            }
+            //전달 받은 sticker이름 확인
             Sticker sticker = stickerRepository.findByStickerName(invitationDto.getSticker())
                     .orElseThrow(() -> new RuntimeException("Fail: sticker not found with name: " + invitationDto.getSticker()));
 

--- a/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
+++ b/src/main/java/com/dnd12/meetinginvitation/invitation/service/InvitationService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -79,11 +80,15 @@ public class InvitationService {
             //전달 받은 배경(Base64로 인코딩된 이미지 파일을 디코딩 해서 특정 경로에 저장 후 해당 url저장)
             String fileUrl = "/getInvitationImage?fileName=" + fileStorageService.saveBase64File(invitationDto.getBackgroundImageData());
 
+            LocalDateTime now = LocalDateTime.now();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            String formatterDateTime = now.format(formatter);
+
             //초대장 생성
             Invitation invitation = Invitation.builder()
                     .user(user)
-                    .createdAt(invitationDto.getCreated_at())
-                    .updatedAt(invitationDto.getUpdated_at())
+                    .createdAt(now)
+                    .updatedAt(now)
                     .place(invitationDto.getPlace())
                     .detailAddress(invitationDto.getDetail_address())
                     .date(invitationDto.getDate())
@@ -319,7 +324,7 @@ public ResponseEntity<ResponseDto> modifyInvitation(Long id, InvitationDto invit
     if (invitationDto.getTitle() != null) {
         invitation.setTitle(invitationDto.getTitle());
     }
-
+    //초대장 업데이트 날짜 갱신
     invitation.setUpdatedAt(LocalDateTime.now());
 
     invitationRepository.save(invitation);


### PR DESCRIPTION
## What is this PR? :mag:

## Changes :memo:
1. 초대장 생성 시 스티커 이름, 편지지 종류 빈값 허용
  + 스티커 이름과 편지지 종류는 빈값이어도 초대장 생성 가능하도록 수정.
  + 폰트의 경우, 없는 이름으로 생성하려고 하면 오류 발생. 따라서 폰트를 생    성하는 API를 통해 폰트를 등록한 후 초대장을 생성해야 함.
2.  타이틀에 이모지 저장 및 조회시 정상 반영
  + 초대장 타이틀에 이모지를 저장하고 조회할 때 정상적으로 반영되도록 인코딩 설정 추가.
3. 초대장 상세 조회 시 DB 설계 이슈
  + 현재 초대장 상세 조회 개발은 완료되었으나, DB 설계 문제로 인해 값이 모두 null로 반환됨. 이를 수정할 예정.
4. 초대장 생성 및 수정 시 created_at, updated_at 파라미터 처리
  + 초대장 생성 시 created_at과 updated_at을 파라미터로 받지 않고, DB에서 자동으로 세팅되도록 변경.
5. 주최자명 추가 및 초대장 조회 시 주최자 이름 반환
  + 초대장 생성 시 주최자명을 파라미터로 추가.
  + 초대장 조회 시 주최자 이름을 반환하도록 수정.
  + 초대장 수정 시 주최자 이름은 변경할 수 없도록 처리.
6. 편지지 종류 API 추가
  + 편지지 종류를 추가하는 API를 새로 구현.
  + 초대장 생성 및 수정 시 편지지 종류를 파라미터로 추가.
## Screenshot :camera:
